### PR TITLE
Fix baseline detection for new games

### DIFF
--- a/utils/db.py
+++ b/utils/db.py
@@ -165,10 +165,26 @@ def get_appids_from_playtime_trend():
     conn.close()
     return appids
 
+def get_appids_from_achievement_trend() -> list[str]:
+    conn = get_connection()
+    c = conn.cursor()
+    c.execute('SELECT DISTINCT appid FROM achievement_trend')
+    appids = [str(row[0]) for row in c.fetchall()]
+    conn.close()
+    return appids
+
 def count_appid_entries(appid: str) -> int:
     conn = get_connection()
     c = conn.cursor()
     c.execute('SELECT COUNT(*) FROM playtime_trend WHERE appid = ?', (appid,))
+    count = c.fetchone()[0]
+    conn.close()
+    return count
+
+def count_achievement_entries(appid: str) -> int:
+    conn = get_connection()
+    c = conn.cursor()
+    c.execute('SELECT COUNT(*) FROM achievement_trend WHERE appid = ?', (appid,))
     count = c.fetchone()[0]
     conn.close()
     return count

--- a/utils/playtime_trend.py
+++ b/utils/playtime_trend.py
@@ -76,7 +76,8 @@ def calculate_daily_minutes(playtime_records):
         today_playtime = record["playtime_minutes"]
 
         if last_playtime is None:
-            diff = today_playtime if today_playtime and today_playtime <= 1440 else 0
+            # Treat the first record as baseline to avoid inflating playtime
+            diff = 0
         else:
             diff = today_playtime - last_playtime if today_playtime is not None else 0
             if diff < 0 or diff > 1440:


### PR DESCRIPTION
## Summary
- avoid counting historical playtime as new by treating first playtime record as baseline
- backfill new games' achievements for all prior dates to avoid spikes
- backfill playtime only when the game has never appeared in the DB

## Testing
- `python -m py_compile utils/playtime_trend.py utils/achievement_trend.py utils/db.py`
- `python - <<'EOF'
from utils.playtime_trend import calculate_daily_minutes
records=[{"date":"2024-04-10","playtime_minutes":1400},{"date":"2024-04-11","playtime_minutes":1400},{"date":"2024-04-12","playtime_minutes":1450}]
print(calculate_daily_minutes(records))
EOF`


------
https://chatgpt.com/codex/tasks/task_e_687e19c178708330b8561b1d969300f0